### PR TITLE
Fix argument parsing bug

### DIFF
--- a/phi/utils/functions.py
+++ b/phi/utils/functions.py
@@ -1,4 +1,6 @@
 import json
+import re
+import ast
 from typing import Optional, Dict, Any
 
 from phi.tools.function import Function, FunctionCall
@@ -26,19 +28,29 @@ def get_function_call(
     if call_id is not None:
         function_call.call_id = call_id
     if arguments is not None and arguments != "":
+        _arguments = None
         try:
-            if function_to_call.sanitize_arguments:
-                if "None" in arguments:
-                    arguments = arguments.replace("None", "null")
-                if "True" in arguments:
-                    arguments = arguments.replace("True", "true")
-                if "False" in arguments:
-                    arguments = arguments.replace("False", "false")
             _arguments = json.loads(arguments)
-        except Exception as e:
-            logger.error(f"Unable to decode function arguments:\n{arguments}\nError: {e}")
-            function_call.error = f"Error while decoding function arguments: {e}\n\n Please make sure we can json.loads() the arguments and retry."
-            return function_call
+        except Exception:
+            if function_to_call.sanitize_arguments:
+                # Try parsing by replacing JSON literals with python literals
+                tmp_args = re.sub(r"\bnull\b", "None", arguments)
+                tmp_args = re.sub(r"\btrue\b", "True", tmp_args)
+                tmp_args = re.sub(r"\bfalse\b", "False", tmp_args)
+                try:
+                    _arguments = ast.literal_eval(tmp_args)
+                except Exception as e:
+                    logger.error(
+                        f"Unable to decode function arguments:\n{arguments}\nError: {e}"
+                    )
+                    function_call.error = (
+                        f"Error while decoding function arguments: {e}\n\n Please make sure we can parse the arguments and retry."
+                    )
+                    return function_call
+            else:
+                logger.error(f"Unable to decode function arguments:\n{arguments}")
+                function_call.error = "Error while decoding function arguments."
+                return function_call
 
         if not isinstance(_arguments, dict):
             logger.error(f"Function arguments are not a valid JSON object: {arguments}")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,46 @@
+import sys
+import sys
+import types
+import pydantic
+
+# Stub rich.logging.RichHandler if rich is not installed
+if 'rich.logging' not in sys.modules:
+    class RichHandler:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def setFormatter(self, *args, **kwargs):
+            pass
+
+    rich_logging = types.SimpleNamespace(RichHandler=RichHandler)
+    sys.modules['rich.logging'] = rich_logging
+
+if not hasattr(pydantic, "validate_call"):
+    def validate_call(func):
+        return func
+
+    pydantic.validate_call = validate_call
+
+fake_settings = types.SimpleNamespace(
+    phi_cli_settings=types.SimpleNamespace(api_runtime="dev")
+)
+sys.modules.setdefault("phi.cli.settings", fake_settings)
+
+from phi.tools.function import Function
+from phi.utils.functions import get_function_call
+
+
+def dummy(name: str, flag: bool, greeting: str) -> str:
+    return f"{name}:{flag}:{greeting}"
+
+
+def test_get_function_call_sanitization():
+    func = Function(name="dummy", entrypoint=dummy)
+    args = '{"name": "Truedraw", "flag": True, "greeting": "Hello True"}'
+    fc = get_function_call("dummy", arguments=args, functions={"dummy": func})
+    assert fc is not None
+    assert fc.arguments == {
+        "name": "Truedraw",
+        "flag": True,
+        "greeting": "Hello True",
+    }


### PR DESCRIPTION
## Summary
- fix sanitization logic in `get_function_call` to avoid replacing text within quoted strings
- parse fallback using `ast.literal_eval` for python-style arguments
- add regression test for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bbf9ddd88320859cee3d563bbafa